### PR TITLE
KITTI 데이터셋 지원 및 3D SLAM 파이프라인 고도화

### DIFF
--- a/config/slam_config.py
+++ b/config/slam_config.py
@@ -176,6 +176,7 @@ class PoseGraphConfig:
     scale_weight: float = 1.0                     # Sim3 스케일 자유도 가중치 (루프 엣지)
     essential_translation_weight: float = 1e-3    # Essential 루프: 병진 스케일 불확실 → 회전만 신뢰
     iterations: int = 20
+    optimize_every_n_loops: int = 5               # 루프 N개마다 PGO 실행 (첫 루프는 즉시, 종료 시 항상 1회)
 
 
 @dataclass

--- a/config/slam_config.py
+++ b/config/slam_config.py
@@ -191,6 +191,7 @@ class VizConfig:
     keypoint_radius: int = 2
     voxel_size: float = 0.1
     point_size: float = 3.0
+    topdown_features: bool = True   # topdown_map.png에 특징점 표시 (False면 경로만)
 
 
 @dataclass

--- a/scripts/superpoint_app.py
+++ b/scripts/superpoint_app.py
@@ -106,6 +106,8 @@ def build_parser():
     # === 성능 최적화 파라미터 (3D SLAM 전용) ===
     parser.add_argument("--no-viz", action="store_true",
                         help="실시간 2D 시각화 비활성화 (성능 향상: ~15-20ms)")
+    parser.add_argument("--topdown-features", action=argparse.BooleanOptionalAction, default=True,
+                        help="topdown_map.png에 특징점 표시 (--no-topdown-features면 경로만)")
     parser.add_argument("--sp-scale", type=float, default=1.0,
                         help="SuperPoint 추론 해상도 스케일 (0.5 = 절반 해상도, 기본: 1.0)")
     parser.add_argument("--sp-interval", type=int, default=1,
@@ -177,6 +179,8 @@ _CLI_MAP = {
     # performance
     "local_map_limit": "performance.local_map_limit",
     "filter_on_sp_only": "performance.filter_on_sp_only",
+    # viz
+    "topdown_features": "viz.topdown_features",
 }
 
 

--- a/slam/slam_visualizer.py
+++ b/slam/slam_visualizer.py
@@ -140,7 +140,9 @@ class SLAMVisualizer:
             traj_2d = traj_pts[:, [0, 2]]
             map_3d = np.asarray(pcd.points)
             map_2d = map_3d[:, [0, 2]] if len(map_3d) > 0 else np.empty((0, 2))
-            map_img = render_topdown_map(traj_2d, map_2d)
+            # 특징점 표시 여부: config viz.topdown_features (기본 True). False면 경로만.
+            show_feat = getattr(self.cfg, "topdown_features", True)
+            map_img = render_topdown_map(traj_2d, map_2d, show_features=show_feat)
             cv2.imwrite(os.path.join(self.save_dir, "topdown_map.png"), map_img)
             np.savetxt(os.path.join(self.save_dir, "trajectory_xy.txt"), traj_2d, fmt="%.4f")
             logger.info("Topdown Map saved to: %s", os.path.join(self.save_dir, "topdown_map.png"))

--- a/slam/topdown_render.py
+++ b/slam/topdown_render.py
@@ -22,8 +22,9 @@ def render_topdown_map(
     is_floor_array: np.ndarray | None = None,
     canvas_size: tuple[int, int] = (800, 800),
     margin: int = 40,
+    show_features: bool = True,
 ) -> np.ndarray:
-    """탑다운 맵 렌더링 (경로 + 특징점 단순 표시)
+    """탑다운 맵 렌더링 (경로 + 선택적 특징점 표시)
 
     Args:
         trajectory_xy: 카메라 경로 좌표 (N, 2)
@@ -31,20 +32,24 @@ def render_topdown_map(
         is_floor_array: 바닥 여부 배열 (M,), True면 바닥(빨간색), False면 사물(파란색)
         canvas_size: 출력 이미지 크기 (H, W)
         margin: 여백
+        show_features: False면 특징점을 그리지 않고 경로만 표시 (뷰 스케일도 경로 기준)
 
     Legend:
         - 파란색 점: 사물(구조물) 위치
         - 빨간색 점: 바닥 위치
         - 녹색 선: 카메라 이동 경로
-        - 파란점: 시작점
-        - 빨간점: 끝점
+        - 주황점: 시작점 / 자주점: 끝점
     """
     h, w = canvas_size
     canvas = np.full((h, w, 3), 255, dtype=np.uint8)  # 흰 배경
 
+    draw_features = show_features and len(map_xy) > 0
+
     if len(trajectory_xy) == 0 and len(map_xy) == 0:
         return canvas
 
+    # 뷰 스케일 계산: 특징점을 '그리지 않아도' 맵 범위를 포함해 스케일을 잡아야
+    # 특징점 표시 여부와 무관하게 궤적의 크기·위치가 동일하게 유지된다.
     all_pts = []
     if len(trajectory_xy) > 0:
         all_pts.append(trajectory_xy)
@@ -67,24 +72,27 @@ def render_topdown_map(
         p[:, 1] = h - p[:, 1]
         return p.astype(np.int32)
 
-    # 1. 특징점 표시 (바닥/사물 구분)
+    # 1. 특징점 필터링(범례 계산에 필요) + 원 그리기(show_features=False면 그리기만 생략).
+    #    → 특징점을 빼도 뷰 스케일/범례는 특징점 버전과 완전히 동일하게 유지됨.
+    filtered_map_xy = np.empty((0, 2))
     if len(map_xy) > 0:
         filtered_map_xy = filter_sparse_points(map_xy, cell_size=1.0, min_count=1)
-        map_px = project(filtered_map_xy)
-        # display every 2nd point to reduce clutter
-        map_px = map_px[::2]
+        if show_features:
+            map_px = project(filtered_map_xy)
+            # display every 2nd point to reduce clutter
+            map_px = map_px[::2]
 
-        # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
-        if is_floor_array is not None and len(is_floor_array) == len(map_xy):
-            for i, pt in enumerate(map_px):
-                if is_floor_array[i if i < len(is_floor_array) else -1]:
-                    cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
-                else:
-                    cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
-        else:
-            # 기본: 모두 파란색
-            for pt in map_px:
-                cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
+            # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
+            if is_floor_array is not None and len(is_floor_array) == len(map_xy):
+                for i, pt in enumerate(map_px):
+                    if is_floor_array[i if i < len(is_floor_array) else -1]:
+                        cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
+                    else:
+                        cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
+            else:
+                # 기본: 모두 파란색
+                for pt in map_px:
+                    cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
 
     # 2. 경로 표시 - 진한 녹색 선 (두께 증가)
     if len(trajectory_xy) > 1:
@@ -94,7 +102,7 @@ def render_topdown_map(
         cv2.circle(canvas, tuple(traj_px[0]), 7, (0, 165, 255), -1, lineType=cv2.LINE_AA)    # 시작: 주황
         cv2.circle(canvas, tuple(traj_px[-1]), 7, (255, 0, 255), -1, lineType=cv2.LINE_AA)   # 끝: 자주
 
-    # 3. 범례 추가
+    # 3. 범례 추가 — show_features 여부와 무관하게 동일 (특징점만 안 그릴 뿐)
     feature_count = len(filtered_map_xy) if len(map_xy) > 0 else 0
     floor_count = int(np.sum(is_floor_array)) if is_floor_array is not None else 0
     object_count = feature_count - floor_count

--- a/slam/topdown_render.py
+++ b/slam/topdown_render.py
@@ -23,35 +23,27 @@ def render_topdown_map(
     canvas_size: tuple[int, int] = (800, 800),
     margin: int = 40,
 ) -> np.ndarray:
-    """탑다운 맵 렌더링 (경로 + 특징점 단순 표시)
+    """탑다운 맵 렌더링 (경로만 표시)
 
     Args:
         trajectory_xy: 카메라 경로 좌표 (N, 2)
-        map_xy: 맵 특징점 좌표 (M, 2)
-        is_floor_array: 바닥 여부 배열 (M,), True면 바닥(빨간색), False면 사물(파란색)
+        map_xy: 맵 특징점 좌표 (M, 2), 현재 렌더링에는 사용하지 않음
+        is_floor_array: 바닥 여부 배열 (M,), 현재 렌더링에는 사용하지 않음
         canvas_size: 출력 이미지 크기 (H, W)
         margin: 여백
 
     Legend:
-        - 파란색 점: 사물(구조물) 위치
-        - 빨간색 점: 바닥 위치
         - 녹색 선: 카메라 이동 경로
-        - 파란점: 시작점
-        - 빨간점: 끝점
+        - 주황색 점: 시작점
+        - 자주색 점: 끝점
     """
     h, w = canvas_size
     canvas = np.full((h, w, 3), 255, dtype=np.uint8)  # 흰 배경
 
-    if len(trajectory_xy) == 0 and len(map_xy) == 0:
+    if len(trajectory_xy) == 0:
         return canvas
 
-    all_pts = []
-    if len(trajectory_xy) > 0:
-        all_pts.append(trajectory_xy)
-    if len(map_xy) > 0:
-        all_pts.append(map_xy)
-    all_pts = np.vstack(all_pts)
-
+    all_pts = trajectory_xy
     min_xy = all_pts.min(axis=0)
     max_xy = all_pts.max(axis=0)
     span = np.maximum(max_xy - min_xy, 1e-6)

--- a/slam/topdown_render.py
+++ b/slam/topdown_render.py
@@ -23,27 +23,35 @@ def render_topdown_map(
     canvas_size: tuple[int, int] = (800, 800),
     margin: int = 40,
 ) -> np.ndarray:
-    """탑다운 맵 렌더링 (경로만 표시)
+    """탑다운 맵 렌더링 (경로 + 특징점 단순 표시)
 
     Args:
         trajectory_xy: 카메라 경로 좌표 (N, 2)
-        map_xy: 맵 특징점 좌표 (M, 2), 현재 렌더링에는 사용하지 않음
-        is_floor_array: 바닥 여부 배열 (M,), 현재 렌더링에는 사용하지 않음
+        map_xy: 맵 특징점 좌표 (M, 2)
+        is_floor_array: 바닥 여부 배열 (M,), True면 바닥(빨간색), False면 사물(파란색)
         canvas_size: 출력 이미지 크기 (H, W)
         margin: 여백
 
     Legend:
+        - 파란색 점: 사물(구조물) 위치
+        - 빨간색 점: 바닥 위치
         - 녹색 선: 카메라 이동 경로
-        - 주황색 점: 시작점
-        - 자주색 점: 끝점
+        - 파란점: 시작점
+        - 빨간점: 끝점
     """
     h, w = canvas_size
     canvas = np.full((h, w, 3), 255, dtype=np.uint8)  # 흰 배경
 
-    if len(trajectory_xy) == 0:
+    if len(trajectory_xy) == 0 and len(map_xy) == 0:
         return canvas
 
-    all_pts = trajectory_xy
+    all_pts = []
+    if len(trajectory_xy) > 0:
+        all_pts.append(trajectory_xy)
+    if len(map_xy) > 0:
+        all_pts.append(map_xy)
+    all_pts = np.vstack(all_pts)
+
     min_xy = all_pts.min(axis=0)
     max_xy = all_pts.max(axis=0)
     span = np.maximum(max_xy - min_xy, 1e-6)
@@ -59,24 +67,24 @@ def render_topdown_map(
         p[:, 1] = h - p[:, 1]
         return p.astype(np.int32)
 
-    # 1. 특징점 표시 (바닥/사물 구분) - topdown_map.png에는 경로만 표시하기 위해 비활성화
-    # if len(map_xy) > 0:
-    #     filtered_map_xy = filter_sparse_points(map_xy, cell_size=1.0, min_count=1)
-    #     map_px = project(filtered_map_xy)
-    #     # display every 2nd point to reduce clutter
-    #     map_px = map_px[::2]
-    #
-    #     # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
-    #     if is_floor_array is not None and len(is_floor_array) == len(map_xy):
-    #         for i, pt in enumerate(map_px):
-    #             if is_floor_array[i if i < len(is_floor_array) else -1]:
-    #                 cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
-    #             else:
-    #                 cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
-    #     else:
-    #         # 기본: 모두 파란색
-    #         for pt in map_px:
-    #             cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
+    # 1. 특징점 표시 (바닥/사물 구분)
+    if len(map_xy) > 0:
+        filtered_map_xy = filter_sparse_points(map_xy, cell_size=1.0, min_count=1)
+        map_px = project(filtered_map_xy)
+        # display every 2nd point to reduce clutter
+        map_px = map_px[::2]
+
+        # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
+        if is_floor_array is not None and len(is_floor_array) == len(map_xy):
+            for i, pt in enumerate(map_px):
+                if is_floor_array[i if i < len(is_floor_array) else -1]:
+                    cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
+                else:
+                    cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
+        else:
+            # 기본: 모두 파란색
+            for pt in map_px:
+                cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
 
     # 2. 경로 표시 - 진한 녹색 선 (두께 증가)
     if len(trajectory_xy) > 1:
@@ -87,12 +95,12 @@ def render_topdown_map(
         cv2.circle(canvas, tuple(traj_px[-1]), 7, (255, 0, 255), -1, lineType=cv2.LINE_AA)   # 끝: 자주
 
     # 3. 범례 추가
-    # feature_count = len(filtered_map_xy) if len(map_xy) > 0 else 0
-    # floor_count = int(np.sum(is_floor_array)) if is_floor_array is not None else 0
-    # object_count = feature_count - floor_count
-    #
-    # cv2.putText(canvas, f"Features: {feature_count} (Floor: {floor_count}, Objects: {object_count})", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
-    # cv2.putText(canvas, f"Blue=Objects | Red=Floor", (12, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
-    cv2.putText(canvas, f"Path: {len(trajectory_xy)}", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 150, 0), 1)
+    feature_count = len(filtered_map_xy) if len(map_xy) > 0 else 0
+    floor_count = int(np.sum(is_floor_array)) if is_floor_array is not None else 0
+    object_count = feature_count - floor_count
+
+    cv2.putText(canvas, f"Features: {feature_count} (Floor: {floor_count}, Objects: {object_count})", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
+    cv2.putText(canvas, f"Blue=Objects | Red=Floor", (12, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
+    cv2.putText(canvas, f"Path: {len(trajectory_xy)}", (12, 80), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 150, 0), 1)
 
     return canvas

--- a/slam/topdown_render.py
+++ b/slam/topdown_render.py
@@ -59,24 +59,24 @@ def render_topdown_map(
         p[:, 1] = h - p[:, 1]
         return p.astype(np.int32)
 
-    # 1. 특징점 표시 (바닥/사물 구분)
-    if len(map_xy) > 0:
-        filtered_map_xy = filter_sparse_points(map_xy, cell_size=1.0, min_count=1)
-        map_px = project(filtered_map_xy)
-        # display every 2nd point to reduce clutter
-        map_px = map_px[::2]
-
-        # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
-        if is_floor_array is not None and len(is_floor_array) == len(map_xy):
-            for i, pt in enumerate(map_px):
-                if is_floor_array[i if i < len(is_floor_array) else -1]:
-                    cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
-                else:
-                    cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
-        else:
-            # 기본: 모두 파란색
-            for pt in map_px:
-                cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
+    # 1. 특징점 표시 (바닥/사물 구분) - topdown_map.png에는 경로만 표시하기 위해 비활성화
+    # if len(map_xy) > 0:
+    #     filtered_map_xy = filter_sparse_points(map_xy, cell_size=1.0, min_count=1)
+    #     map_px = project(filtered_map_xy)
+    #     # display every 2nd point to reduce clutter
+    #     map_px = map_px[::2]
+    #
+    #     # 바닥/사물 정보가 있으면 필터링된 인덱스 추적
+    #     if is_floor_array is not None and len(is_floor_array) == len(map_xy):
+    #         for i, pt in enumerate(map_px):
+    #             if is_floor_array[i if i < len(is_floor_array) else -1]:
+    #                 cv2.circle(canvas, tuple(pt), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)  # 빨간색 (바닥)
+    #             else:
+    #                 cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)  # 파란색 (사물)
+    #     else:
+    #         # 기본: 모두 파란색
+    #         for pt in map_px:
+    #             cv2.circle(canvas, tuple(pt), 1, (255, 0, 0), -1, lineType=cv2.LINE_AA)
 
     # 2. 경로 표시 - 진한 녹색 선 (두께 증가)
     if len(trajectory_xy) > 1:
@@ -87,12 +87,12 @@ def render_topdown_map(
         cv2.circle(canvas, tuple(traj_px[-1]), 7, (255, 0, 255), -1, lineType=cv2.LINE_AA)   # 끝: 자주
 
     # 3. 범례 추가
-    feature_count = len(filtered_map_xy) if len(map_xy) > 0 else 0
-    floor_count = int(np.sum(is_floor_array)) if is_floor_array is not None else 0
-    object_count = feature_count - floor_count
-
-    cv2.putText(canvas, f"Features: {feature_count} (Floor: {floor_count}, Objects: {object_count})", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
-    cv2.putText(canvas, f"Blue=Objects | Red=Floor", (12, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
-    cv2.putText(canvas, f"Path: {len(trajectory_xy)}", (12, 80), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 150, 0), 1)
+    # feature_count = len(filtered_map_xy) if len(map_xy) > 0 else 0
+    # floor_count = int(np.sum(is_floor_array)) if is_floor_array is not None else 0
+    # object_count = feature_count - floor_count
+    #
+    # cv2.putText(canvas, f"Features: {feature_count} (Floor: {floor_count}, Objects: {object_count})", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 2)
+    # cv2.putText(canvas, f"Blue=Objects | Red=Floor", (12, 55), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
+    cv2.putText(canvas, f"Path: {len(trajectory_xy)}", (12, 25), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 150, 0), 1)
 
     return canvas

--- a/slam/visual_slam_3d.py
+++ b/slam/visual_slam_3d.py
@@ -200,6 +200,11 @@ class VisualSLAM3D:
         self.traj_points = []
         self.last_keyframe_idx = 0
 
+        # PGO 스로틀: 루프마다 전체 그래프 재최적화는 루프가 많은 시퀀스(KITTI 00)에서
+        # 비용 폭증 → 첫 루프는 즉시, 이후 N개 누적 시에만 실행 (종료 시 최종 1회는 항상)
+        self._loops_since_pgo = 0
+        self._pgo_runs = 0
+
         # 포즈 안정화 + 추정 모듈
         self.stabilizer = PoseStabilizer(c.stabilization)
         self.pose_estimator = PoseEstimator(self.K, c.pnp, c.motion, c.epipolar)
@@ -766,7 +771,12 @@ class VisualSLAM3D:
                 'method': loop.method,     # 'pnp'(metric 병진) / 'ess'(회전만)
                 'information_scale': 1.0,
             })
-            self.optimize_pose_graph()
+            # 스로틀: 첫 루프는 즉시(초기 드리프트 교정), 이후 N개 누적 시 실행
+            self._loops_since_pgo += 1
+            if self._pgo_runs == 0 or self._loops_since_pgo >= self.cfg.pose_graph.optimize_every_n_loops:
+                self.optimize_pose_graph()
+                self._loops_since_pgo = 0
+                self._pgo_runs += 1
 
         # LBA는 실시간 추적 시 cur_pose를 오염시키므로 비활성화
         # GBA만 후처리로 실행합니다 (process() 루프 종료 후)
@@ -777,7 +787,9 @@ class VisualSLAM3D:
             logger.warning("g2o not available - pose graph optimization skipped")
             return None
         optimizer = g2o.SparseOptimizer()
-        solver = g2o.BlockSolverSim3(g2o.LinearSolverDenseSim3())
+        # 포즈 그래프는 희소(체인+소수 루프 엣지) → Eigen sparse 솔버 사용.
+        # Dense 솔버는 키프레임 1000개 규모(KITTI 00)에서 루프마다 수십 초 소요.
+        solver = g2o.BlockSolverSim3(g2o.LinearSolverEigenSim3())
         algorithm = g2o.OptimizationAlgorithmLevenberg(solver)
         optimizer.set_algorithm(algorithm)
         return optimizer
@@ -887,8 +899,11 @@ class VisualSLAM3D:
             edge_count += 1
 
         # 3. 최적화 실행
+        _pgo_t0 = time.perf_counter()
         optimizer.initialize_optimization()
         optimizer.optimize(pg.iterations)
+        logger.info("[Pose Graph] optimized %d nodes / %d edges in %.2fs",
+                    n_kf, edge_count, time.perf_counter() - _pgo_t0)
 
         # 4. 결과 추출 → 키프레임 포즈 갱신 (Sim3 → T_wc, metric)
         for i in range(n_kf):


### PR DESCRIPTION
## Summary
  - Sim3(7-DOF) PGO 전환 및 루프 클로저 전면 개편으로 스케일 드리프트 보정 지원
  - KITTI 시퀀스별 config 분리 (kitti_urban / kitti_highway) 및 검증값 동기화
  - v14 디스크립터 헤드 붕괴 복구를 위한 재증류 스크립트 및 가중치 추가
  - 매처 디바이스·필터·렌더링 최적화 (프레임당 ~15ms 절감)
  - PGO를 sparse 솔버로 전환하고 루프마다 재실행 스로틀링
  - topdown 맵 특징점 표시 토글 옵션 추가 (`--topdown-features` / `--no-topdown-features`)
  - 미사용 가중치·고아 파일 정리 및 문서 전면 갱신

  ## Changes
  - **SLAM 코어**: Sim3 PGO, 루프 클로저 개편, sparse 솔버 전환
  - **Config**: KITTI용 yaml 용도 기준 정리, `VizConfig.topdown_features` 추가
  - **학습**: `finetune_descriptor.py` 재증류 스크립트, v14_desc_ft 가중치
  - **시각화**: topdown 렌더러 특징점 토글, GT 시각화 스크립트 추가
  - **정리**: 미사용 가중치 삭제, 파일명 리팩터, 문서 갱신

  ## Test plan
  - [ ] `kitti_urban.yaml`로 KITTI-08 시퀀스 구동 후 ATE 확인
  - [ ] `kitti_highway.yaml`로 KITTI-01 시퀀스 구동 확인
  - [ ] `--no-topdown-features` 옵션으로 경로만 출력되는지 확인
  - [ ] PGO sparse 솔버 정상 수렴 확인